### PR TITLE
最終ログイン日時の修正

### DIFF
--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -2,6 +2,7 @@
 class IndexController < ApplicationController
   # トップ画面
   def index
+    logger.debug('IndexController start')
     render 'top'
   end
 end

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,8 +1,9 @@
 # トップ画面
 class IndexController < ApplicationController
   # トップ画面
+  # /
   def index
-    logger.debug('IndexController start')
+    logger.debug('Log IndexController method start')
     render 'top'
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,12 +5,13 @@ class SessionsController < ApplicationController
   }, only: [:new, :create]
 
   # ログイン画面
+  # /login
   def new
   end
 
   # ログイン送信
+  # /login
   def create
-    # TODO バリデートを行う
     user = User.find_by(email: params[:email])
     if user && user.authenticate(params[:password])
       logger.debug('Log login_success')
@@ -29,7 +30,7 @@ class SessionsController < ApplicationController
   # ログアウト機能
   # /logut
   def destory
-    logger.debug("destory start")
+    logger.debug("Log destory method start")
     logout
     @user = nil
     redirect_to index_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,9 +29,9 @@ class SessionsController < ApplicationController
   # ログアウト機能
   # /logut
   def destory
-    logger.debug("destory_method_start")
+    logger.debug("destory start")
     logout
     @user = nil
-    render "index/top"
+    redirect_to index_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,8 +19,7 @@ class UsersController < ApplicationController
     # /user_create画面
     #　新規ユーザー作成機能
     def create
-        logger.debug('log create_method_start')
-        # TODO バリデート、トランザクション処理、例外処理を行う
+        logger.debug('Log create method start')
         user = User.new
         user.name = params[:name]
         user.email = params[:email]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,6 @@ class User < ApplicationRecord
     def regist_last_login_timestamp(user)
         logger.debug("Log last_login_timestamp_#{Time.now}")
         user.last_login_timestamp = Time.now
-        user.save
+        user.save(validate: false)
     end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,8 +6,9 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "regist_last_login_timestamp_実行後値が登録されていること" do
-    @user.regist_last_login_timestamp(@user)
-    assert @user.last_login_timestamp
+    user = User.find_by(email: 'kuma@syake.ne.jp')
+    user.regist_last_login_timestamp(user)
+    assert user.last_login_timestamp
   end
 
   test "nameが空文字の場合バリデーションに失敗すること" do


### PR DESCRIPTION
saveメソッドでバリデートが動いてしまっていたので、
ログイン時に最終ログイン日時が登録されていなかった。
最終ログイン日時を登録する際はバリデートは必要ないので、
バリデートを動かさずに更新する様にしました。
その他は、不要なコメントの削除などです。